### PR TITLE
Update website in changelog

### DIFF
--- a/GameData/kOS-Astrogator/kOS-Astrogator-Changelog.cfg
+++ b/GameData/kOS-Astrogator/kOS-Astrogator-Changelog.cfg
@@ -3,7 +3,7 @@ KERBALCHANGELOG
 	modName = kOS-Astrogator
 	author = markjfisher
 	license = GPL-3.0
-	website = forum.kerbalspaceprogram.com/index.php?/topic/155998-Astrogator
+	website = forum.kerbalspaceprogram.com/index.php?/topic/209940-kos-astrogator
 	showChangelog = True
 	VERSION
 	{


### PR DESCRIPTION
Setting up a new mod is always tricky, with so many things to create that all link to one another.

The changelog currently uses Astrogator's thread for its website property. Now that you have your own thread (which will be visible again eventually!), KerbalChangelog users will appreciate having it updated.

EDIT: Forgot that GitHub doesn't always send notifications for pull requests, so tagging @markjfisher.